### PR TITLE
a single committer task - simplifies CommitState

### DIFF
--- a/src/Parallafka/MessageCommitter.cs
+++ b/src/Parallafka/MessageCommitter.cs
@@ -102,9 +102,7 @@ namespace Parallafka
         private async Task GetAndCommitAnyMessages()
         {
             Parallafka<TKey, TValue>.WriteLine("GetAndCommitAnyMessages start");
-            var messages = this._commitState.GetMessagesToCommit().ToList();
-
-            foreach (var message in messages)
+            foreach (var message in this._commitState.GetMessagesToCommit())
             {
                 await CommitMessage(message);
             }

--- a/src/Parallafka/MessageCommitter.cs
+++ b/src/Parallafka/MessageCommitter.cs
@@ -29,7 +29,7 @@ namespace Parallafka
                 new ExecutionDataflowBlockOptions
                 {
                     MaxDegreeOfParallelism = 1,
-                    BoundedCapacity = 1
+                    BoundedCapacity = 2
                 });
 
             this._committedStates = new();

--- a/src/Parallafka/MessageCommitter.cs
+++ b/src/Parallafka/MessageCommitter.cs
@@ -31,7 +31,8 @@ namespace Parallafka
             this._commitActBlock = new ActionBlock<int>(_ => GetAndCommitAnyMessages(),
                 new ExecutionDataflowBlockOptions
                 {
-                    MaxDegreeOfParallelism = 1
+                    MaxDegreeOfParallelism = 1,
+                    BoundedCapacity = 1
                 });
 
             this._commitBlock.LinkTo(this._commitActBlock, new DataflowLinkOptions { PropagateCompletion = true });

--- a/src/Parallafka/Parallafka.cs
+++ b/src/Parallafka/Parallafka.cs
@@ -66,7 +66,7 @@ namespace Parallafka
                 this._logger, 
                 this._config.CommitDelay ?? TimeSpan.FromSeconds(5), 
                 localStop.Token);
-            var committerTarget = new ActionBlock<IKafkaMessage<TKey, TValue>>(committer.TryCommitMessage,
+            var committerTarget = new ActionBlock<IKafkaMessage<TKey, TValue>>(m => committer.CommitNow(),
                 new ExecutionDataflowBlockOptions
                 {
                     BoundedCapacity = 100,

--- a/tests/Parallafka.Tests/MessageCommitterTests.cs
+++ b/tests/Parallafka.Tests/MessageCommitterTests.cs
@@ -17,7 +17,7 @@ namespace Parallafka.Tests
         [InlineData(false)]
         public async Task CommitsSimpleRecordAsync(bool wasHandled)
         {
-            Parallafka<string, string>.WriteLine = s => this._output.WriteLine(s);
+            // Parallafka<string, string>.WriteLine = s => this._output.WriteLine(s);
             // given
             var consumer = new Mock<IKafkaConsumer<string, string>>();
             var logger = new Mock<ILogger>();


### PR DESCRIPTION
TODO: use a single array instead of a ConcurrentQueue/Semaphore Combination.  I've used this type of object in the past, I might have some C# code sitting around so I don't have to re-write it.

This array object allows non-locked readers and writers, but it doesn't enable async-blocking.  But this PR as it stands is a good start without getting into some funky data structures to save a few cpu cycles.

I don't think I can eliminate the Semaphore _canQueueMessage, but we can eliminate the ConcurrentQueue - I'm just not sure that [single array] object is worth the effort yet.